### PR TITLE
Revert "Quick typo fix"

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         <dt>How fast do people go?</dt>
         <dd>
           Its not a super speedy group ride. Faster than Bike Party or Critical
-          Mass, but its still a no drop, everyone is welcome to ride.
+          Mass, but its still a no drop, everyone is welcome ride.
         </dd>
         <dt>What kinda bike should I bring?</dt>
         <dd>


### PR DESCRIPTION
Reverts skalnik/butterlap.bike#8.

I didn't read this clearly, as pointed out by @sshirokov, this turns the noun into a verb. "still a … to ride", which isn't correct. This is a description of the ride and read correctly originally.