### PR TITLE
Remove COVID alert and Bender's avoidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,20 +25,6 @@
           At <a href="https://www.ferrybuildingmarketplace.com/merchants/fort-point-beer-company/">Fort Point</a> in <a href="https://goo.gl/maps/yKgBhgN8JxE2">The Ferry Building</a>.
         <dd>
       </dl>
-      <div class="alert alert-info" role="alert">
-        <p>
-          <strong>COVID-19 update</strong>: There's still a group that rides every Wednesday, but
-          obviously there's no beer or snack sharing. Please wear a <a
-          href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover-guidance.html">mask</a>
-          that fits over your nose and mouth at all times during the ride.
-        </p>
-        <hr>
-        <p class="mb-0">
-          Many people split apart around Legion of Honor to go home, up Twin
-          Peaks, or to <a href="https://eattopround.com/san-francisco">Top
-          Round</a>.
-        </p>
-      </div>
       <h2>Map</h2>
       <figure class="figure">
         <a href="route.png">
@@ -58,11 +44,7 @@
         <li>Clement &amp; 43rd Ave. <small>Regroup for the Hospital Lap.</small></li>
         <li>Ocean Beach. <small>Mini-regroup post-hospital lap.</small></li>
         <li>Panhandle. <small>Final regroup. Lots of folks head home.</small></li>
-        <li>
-          <s>
-            <a href="https://www.bendersbar.com">Bender's Bar &amp; Grill</a>
-          </s>. Currently, Bender's closes early so no one is going.
-        </li>
+        <li><a href="https://www.bendersbar.com">Bender's Bar &amp; Grill</a></li>
       </ol>
 
       <h2>FAQ</h2>
@@ -121,15 +103,6 @@
           <p>
             Usually folks hit the Panhandle at 9:45-10:15. Bender's about 15-30 minutes
             after that.
-          </p>
-        </dd>
-        <dt>But Benders is closed right now?</dt>
-        <dd>
-          <p>
-            And we're very sad about it. In the mean time some have decided that
-            <a href="https://eattopround.com/san-francisco">Top Round</a> in The
-            Mission is both open late, and good to stop by after. Others just go
-            up Twin Peaks and then home.
           </p>
         </dd>
         <dt>I found something wrong on this website. How can I fix it?!</dt>


### PR DESCRIPTION
Masks aren't required in San Francisco for events this small and Bender's is allowing bikes inside again. This PR removes some of the COVID specific language and Bender's closes early text.